### PR TITLE
fixes include:

### DIFF
--- a/WAM_Coursework/Conferences/Talk.cs
+++ b/WAM_Coursework/Conferences/Talk.cs
@@ -11,6 +11,11 @@ namespace WAM_Coursework.Conferences
         private TalkRecord record = new TalkRecord();
 
         /// <summary>
+        /// Parameterless constructor for deserialization (e.g., from CSV).
+        /// </summary>
+        public Talk() { }
+
+        /// <summary>
         /// Talk class constructor.
         /// </summary>
         /// <param name="title">Title of talk.</param>
@@ -27,6 +32,7 @@ namespace WAM_Coursework.Conferences
             record.Id = FileManager.CreateNewId<TalkRecord>(FileManager.StorageFile.talks);
             record.Datetime = DateTime.Now.ToString();
             record.ReviewPassed = false;
+            record.SubmittedToConference = false;
         }
 
         public int Id { get => record.Id; set => record.Id = value; }
@@ -39,5 +45,6 @@ namespace WAM_Coursework.Conferences
         public string Reviewer2Email { get => record.Reviewer2Email; set => record.Reviewer2Email = value; }
         public bool ReviewPassed { get => record.ReviewPassed; set => record.ReviewPassed = value; }
 
+        public bool SubmittedToConference { get => record.SubmittedToConference; set => record.SubmittedToConference = value; }
     }
 }

--- a/WAM_Coursework/Conferences/TalkRecord.cs
+++ b/WAM_Coursework/Conferences/TalkRecord.cs
@@ -14,5 +14,7 @@
         public string Reviewer2Email { get; set; }
         public bool ReviewPassed { get; set; } = false;
 
+        public bool SubmittedToConference { get; set; } = false;
+
     }
 }

--- a/WAM_Coursework/Forms/Manager/NewConferenceForm.cs
+++ b/WAM_Coursework/Forms/Manager/NewConferenceForm.cs
@@ -50,7 +50,7 @@ namespace WAM_Coursework.Forms
 
             foreach (var talk in eligibleTalks)
             {
-                talk.ReviewPassed = true;
+                talk.SubmittedToConference = true;
                 FileManager.UpdateRecord(talk, FileManager.StorageFile.talks);
             }
 

--- a/WAM_Coursework/Forms/Reviewer/ReviewerMainForm.cs
+++ b/WAM_Coursework/Forms/Reviewer/ReviewerMainForm.cs
@@ -33,15 +33,17 @@ namespace WAM_Coursework.Forms
             List<TalkRecord> Talks = FileManager.ReadRecords<TalkRecord>(FileManager.StorageFile.talks);
             List<TalkRecord> Assigned = Talks.FindAll(t => t.Reviewer1Email == userEmail || t.Reviewer2Email == userEmail);
 
-            foreach (var talk in Assigned)
+            foreach (var talk in Assigned) if (!talk.ReviewPassed)
             {
+                int talkId = talk.Id;
                 //add application to reviewer homepage list as a button.
-                Button talkbutton = new Button() { Text = talk.Title + "\t - " + talk.Description + "\t- " + (talk.ReviewPassed ? "Approved" : "Pending") };
+                Button talkbutton = new Button() { Text = talk.Title + "\t - " + talk.Description };
                 talkbutton.Font = new System.Drawing.Font(talkbutton.Font.FontFamily, 20);
                 talkbutton.BackColor = System.Drawing.Color.FromArgb(54, 54, 54);
                 talkbutton.ForeColor = System.Drawing.Color.White;
                 talkbutton.AutoSize = true;
-                talkbutton.Click += (sender, e) => OpenReview(sender, e, talk.Id);
+                talkbutton.Tag = talkId;
+                talkbutton.Click += (sender, e) => OpenReview(sender, e, (int)((Button)sender).Tag);
                 ReviewsFlowPanel.Controls.Add(talkbutton);
             }
             CountBadge.Text = Assigned.Count.ToString() + " remaining";
@@ -57,6 +59,10 @@ namespace WAM_Coursework.Forms
         {
             SubmitReviewForm submitForm = new SubmitReviewForm(talkId.ToString());
             submitForm.ShowDialog();
+            if (submitForm.DialogResult == DialogResult.OK)
+            {
+                UpdateReadyToReviewList();
+            }
         }
 
         /// <summary>

--- a/WAM_Coursework/Forms/Reviewer/SubmitReviewForm.cs
+++ b/WAM_Coursework/Forms/Reviewer/SubmitReviewForm.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using System.Threading.Tasks;
 using System.Windows.Forms;
 using WAM_Coursework.Conferences;
 using WAM_Coursework.FileHandlers;
@@ -39,6 +40,10 @@ namespace WAM_Coursework.Forms
         private void SubmitReviewButton_Click(object sender, System.EventArgs e)
         {
             CurrentUser.Instance.User.CreateAction($"{reviewID},{int.Parse(talkID)},{ScoreComboBox.SelectedItem},{ReasonTextBox.Text.Replace(",", "%")}");
+            TalkRecord talks = FileManager.ReadRecords<TalkRecord>(FileManager.StorageFile.talks).Where(t => t.Id == int.Parse(talkID)).FirstOrDefault();
+            talks.ReviewPassed = true;
+            FileManager.UpdateRecord(talks, FileManager.StorageFile.talks);
+            this.DialogResult = DialogResult.OK;
             Close();
         }
 


### PR DESCRIPTION
ID no longer are all the same they are unique and don't change when new talks are created

reviewer buttons now open the correct talk

reviewer buttons now are updated when review is sent off

new column added for talk to differ from  approved by reviewer talk and submitted to conference talks

fixes #17 
fixes #24 
fixes #20 